### PR TITLE
Add #lte_business_day, #gte_business_day, #is_workday?  and build index for perfomance

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,9 @@ Or install it yourself as:
 
 ```ruby
 RussianProductionCalendar.is_holiday?(Date.parse('01.01.2018'))
+RussianProductionCalendar.is_workday?(Date.parse('01.01.2018'))
+RussianProductionCalendar.lte_business_day(Date.parse('01.01.2018'))
+RussianProductionCalendar.gte_business_day(Date.parse('01.01.2018'))
 ```
 ## Development
 

--- a/bin/console
+++ b/bin/console
@@ -1,14 +1,7 @@
 #!/usr/bin/env ruby
 
-require "bundler/setup"
-require "russian_production_calendar"
+require 'bundler/setup'
+require 'russian_production_calendar'
+require 'pry'
 
-# You can add fixtures and/or initialization code here to make experimenting
-# with your gem easier. You can also use a different console, if you like.
-
-# (If you use this, don't forget to add pry to your Gemfile!)
-# require "pry"
-# Pry.start
-
-require "irb"
-IRB.start(__FILE__)
+Pry.start

--- a/lib/russian_production_calendar.rb
+++ b/lib/russian_production_calendar.rb
@@ -1,24 +1,88 @@
-require "russian_production_calendar/version"
+require 'russian_production_calendar/version'
 require 'date'
-require 'russian'
 require 'csv'
 
 module RussianProductionCalendar
-
   CALENDAR_PATH = 'russian_production_calendar/holidays.csv'.freeze
+  SHORTENED_POSTFIX = '*'.freeze
+  DAY_SEP = ','.freeze
+
+  MONTHS_MAP = {
+    1 => 'Январь',
+    2 => 'Февраль',
+    3 => 'Март',
+    4 => 'Апрель',
+    5 => 'Май',
+    6 => 'Июнь',
+    7 => 'Июль',
+    8 => 'Август',
+    9 => 'Сентябрь',
+    10 => 'Октябрь',
+    11 => 'Ноябрь',
+    12 => 'Декабрь'
+  }.freeze
 
   extend self
 
-  def csv_calendar
-    @csv_calendar ||= CSV.foreach(File.join(__dir__, CALENDAR_PATH), headers: true).map(&:to_h)
+  # @return [Boolean] true/false - выходной/рабочий
+  # @return [nil] если текущего года/месяца нет в индексе
+  def is_holiday?(date)
+    days = index.dig(date.year, date.month) || return
+    days.include?(date.day)
   end
 
-  def is_holiday?(date)
-    month = Russian.strftime(date, '%B')
-    csv_calendar
-      .find { |record| record['Год/Месяц'] == date.year.to_s }[month]
-      .split(',')
-      .select{ |day| !day[/\*/] } # exclude shortened days
-      .include?(date.day.to_s)
+  # @return [Boolean, nil]
+  def is_workday?(date)
+    result = is_holiday?(date)
+    result.is_a?(NilClass) ? nil : !result
+  end
+
+  # @param [Date]
+  # @return [Date] предыдущий рабочий день (или текущий, если он рабочий)
+  def lte_business_day(day)
+    loop do
+      case is_workday?(day)
+      when true
+        break day
+      when nil
+        break
+      else
+        day = day.prev_day
+      end
+    end
+  end
+
+  # @param [Date]
+  # @return [Date] следующий рабочий день (или текущий, если он рабочий)
+  def gte_business_day(day)
+    loop do
+      case is_workday?(day)
+      when true
+        break day
+      when nil
+        break
+      else
+        day = day.next_day
+      end
+    end
+  end
+
+  def csv_calendar
+    @csv_calendar ||= CSV.open(File.join(__dir__, CALENDAR_PATH), headers: true).map(&:to_h)
+  end
+
+  # @return [Hash([Integer] => Hash([Integer] => [Set]))]
+  # @example {"2018" => { 1 => [1, 2, 3] }}
+  def index
+    @index ||= csv_calendar.each_with_object({}) do |row, object|
+      year = Integer(row.fetch('Год/Месяц'))
+
+      object[year] = MONTHS_MAP.each_with_object({}) do |(ix, name), obj|
+        obj[ix] = row.fetch(name).split(DAY_SEP).each_with_object(Set.new) do |day, result|
+          next if day[SHORTENED_POSTFIX]  # exclude shortened days
+          result.add(Integer(day))
+        end
+      end
+    end
   end
 end

--- a/lib/russian_production_calendar/version.rb
+++ b/lib/russian_production_calendar/version.rb
@@ -1,3 +1,3 @@
 module RussianProductionCalendar
-  VERSION = "0.0.2"
+  VERSION = '0.0.3'.freeze
 end

--- a/russian_production_calendar.gemspec
+++ b/russian_production_calendar.gemspec
@@ -30,8 +30,8 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_development_dependency "bundler", "~> 1.15"
-  spec.add_development_dependency "rake", "~> 10.0"
-  spec.add_development_dependency "minitest", "~> 5.0"
-  spec.add_development_dependency "russian", "~> 0.6"
+  spec.add_development_dependency 'bundler'
+  spec.add_development_dependency 'rake'
+  spec.add_development_dependency 'minitest'
+  spec.add_development_dependency 'pry'
 end

--- a/test/russian_production_calendar_test.rb
+++ b/test/russian_production_calendar_test.rb
@@ -1,24 +1,98 @@
-require "test_helper"
+require 'test_helper'
 
 class RussianProductionCalendarTest < Minitest::Test
   def test_that_it_has_a_version_number
-    refute_nil ::RussianProductionCalendar::VERSION
+    refute_nil RussianProductionCalendar::VERSION
   end
 
   def test_new_year_is_a_holiday
     assert RussianProductionCalendar.is_holiday?(Date.parse('01.01.2018'))
+    refute RussianProductionCalendar.is_workday?(Date.parse('01.01.2018'))
   end
 
   def test_first_working_day_is_not_holiday
-    assert !RussianProductionCalendar.is_holiday?(Date.parse('10.01.2018'))
-  end
-
-  def test_first_working_day_is_not_holiday
-    assert !RussianProductionCalendar.is_holiday?(Date.parse('10.01.2018'))
+    assert RussianProductionCalendar.is_workday?(Date.parse('10.01.2018'))
+    refute RussianProductionCalendar.is_holiday?(Date.parse('10.01.2018'))
   end
 
   def test_shortened_day_is_not_holiday
-    assert !RussianProductionCalendar.is_holiday?(Date.parse('22.02.2018'))
+    assert RussianProductionCalendar.is_workday?(Date.parse('22.02.2018'))
+    refute RussianProductionCalendar.is_holiday?(Date.parse('22.02.2018'))
   end
 
+  def test_unknown_day
+    assert_nil RussianProductionCalendar.is_workday?(Date.parse('01.01.3000'))
+    assert_nil RussianProductionCalendar.is_holiday?(Date.parse('01.01.3000'))
+  end
+
+  # @refs http://www.consultant.ru/law/ref/calendar/proizvodstvennye/2019/
+  def test_each_month_holidays
+    holidays = [
+      Date.parse('01.01.2019'),
+      Date.parse('02.02.2019'),
+      Date.parse('08.03.2019'),
+      Date.parse('13.04.2019'),
+      Date.parse('04.05.2019'),
+      Date.parse('12.06.2019'),
+      Date.parse('20.07.2019'),
+      Date.parse('03.08.2019'),
+      Date.parse('14.09.2019'),
+      Date.parse('05.10.2019'),
+      Date.parse('09.11.2019'),
+      Date.parse('01.12.2019')
+    ]
+
+    holidays.each do |day|
+      assert RussianProductionCalendar.is_holiday?(day)
+      refute RussianProductionCalendar.is_workday?(day)
+    end
+  end
+
+  # @refs http://www.consultant.ru/law/ref/calendar/proizvodstvennye/2019/
+  def test_each_month_workdays
+    holidays = [
+        Date.parse('14.01.2019'),
+        Date.parse('01.02.2019'),
+        Date.parse('07.03.2019'),
+        Date.parse('08.04.2019'),
+        Date.parse('01.05.2019'),
+        Date.parse('11.06.2019'),
+        Date.parse('05.07.2019'),
+        Date.parse('09.08.2019'),
+        Date.parse('20.09.2019'),
+        Date.parse('04.10.2019'),
+        Date.parse('05.11.2019'),
+        Date.parse('31.12.2019')
+    ]
+
+    holidays.each do |day|
+      assert RussianProductionCalendar.is_workday?(day)
+      refute RussianProductionCalendar.is_holiday?(day)
+    end
+  end
+
+  # @refs http://www.consultant.ru/law/ref/calendar/proizvodstvennye/2017/
+  def test_lte_business_day_between_years
+    assert_equal RussianProductionCalendar.lte_business_day(Date.parse('05.01.2018')), Date.parse('29.12.2017')
+  end
+
+  def test_lte_business_current
+    assert_equal RussianProductionCalendar.lte_business_day(Date.parse('01.02.2018')), Date.parse('01.02.2018')
+  end
+
+  def test_lte_business_day_unknown
+    assert_nil RussianProductionCalendar.lte_business_day(Date.parse('01.01.3000'))
+  end
+
+  def test_gte_business_day_between_years
+    assert_equal RussianProductionCalendar.gte_business_day(Date.parse('05.01.2018')), Date.parse('09.01.2018')
+  end
+
+  def test_gte_business_current
+    assert_equal RussianProductionCalendar.gte_business_day(Date.parse('09.01.2018')), Date.parse('09.01.2018')
+  end
+
+  def test_gte_business_day_unknown
+    assert_nil RussianProductionCalendar.gte_business_day(Date.parse('01.01.3000'))
+  end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,4 +1,4 @@
 $LOAD_PATH.unshift File.expand_path("../../lib", __FILE__)
-require "russian_production_calendar"
-
-require "minitest/autorun"
+require 'russian_production_calendar'
+require 'minitest/autorun'
+require 'pry'


### PR DESCRIPTION
@J0n1c так же есть бага в текущей версии, в CSV некоторые праздничные дни помечены `*`, в коде гема такие дни пропускаются (как предпраздничный наверно)

Итого 1 мая и 4 ноября рабочие дни (хотя они выходные)

```ruby
RussianProductionCalendar.is_holiday?(Date.parse('01.05.2019'))
RussianProductionCalendar.is_holiday?(Date.parse('04.11.2019'))
```